### PR TITLE
patch affinity to work with dws

### DIFF
--- a/examples/torch_ddp_benchmark/torch_ddp_benchmark.yaml
+++ b/examples/torch_ddp_benchmark/torch_ddp_benchmark.yaml
@@ -28,9 +28,12 @@ name: torch-ddp-bench
 num_nodes: 2
 
 resources:
-  accelerators: A100:8 # Make sure you use 8 GPU instances
-  use_spot: True
-  cloud: gcp
+  accelerators: H100-MEGA-80GB:8 # Make sure you use 8 GPU instances
+  cloud: kubernetes
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue # this is assigned by your admin
+    kueue.x-k8s.io/priority-class: low-priority
+    max-run-duration-seconds: "3000"
 
 file_mounts: 
   ./torch_ddp_benchmark.py: ./examples/torch_ddp_benchmark/torch_ddp_benchmark.py

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -518,32 +518,32 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                 continue
             pod_spec['metadata']['name'] = pod_name
             pod_spec['metadata']['labels']['component'] = pod_name
-            # For multi-node support, we put a soft-constraint to schedule
-            # worker pods on different nodes than the head pod.
-            # This is not set as a hard constraint because if different nodes
-            # are not available, we still want to be able to schedule worker
-            # pods on larger nodes which may be able to fit multiple SkyPilot
-            # "nodes".
-            pod_spec['spec']['affinity'] = {
-                'podAntiAffinity': {
-                    # Set as a soft constraint
-                    'preferredDuringSchedulingIgnoredDuringExecution': [{
-                        # Max weight to avoid scheduling on the
-                        # same physical node unless necessary.
-                        'weight': 100,
-                        'podAffinityTerm': {
-                            'labelSelector': {
-                                'matchExpressions': [{
-                                    'key': TAG_SKYPILOT_CLUSTER_NAME,
-                                    'operator': 'In',
-                                    'values': [cluster_name_on_cloud]
-                                }]
-                            },
-                            'topologyKey': 'kubernetes.io/hostname'
-                        }
-                    }]
-                }
+        # For multi-node support, we put a soft-constraint to schedule
+        # worker pods on different nodes than the head pod.
+        # This is not set as a hard constraint because if different nodes
+        # are not available, we still want to be able to schedule worker
+        # pods on larger nodes which may be able to fit multiple SkyPilot
+        # "nodes".
+        pod_spec['spec']['affinity'] = {
+            'podAntiAffinity': {
+                # Set as a soft constraint
+                'preferredDuringSchedulingIgnoredDuringExecution': [{
+                    # Max weight to avoid scheduling on the
+                    # same physical node unless necessary.
+                    'weight': 100,
+                    'podAffinityTerm': {
+                        'labelSelector': {
+                            'matchExpressions': [{
+                                'key': TAG_SKYPILOT_CLUSTER_NAME,
+                                'operator': 'In',
+                                'values': [cluster_name_on_cloud]
+                            }]
+                        },
+                        'topologyKey': 'kubernetes.io/hostname'
+                    }
+                }]
             }
+        }
         pod = kubernetes.core_api(context).create_namespaced_pod(
             namespace, pod_spec)
         created_pods[pod.metadata.name] = pod
@@ -657,8 +657,9 @@ def _terminate_node(namespace: str, context: Optional[str],
         kubernetes_utils.clean_zombie_ssh_jump_pod(namespace, context, pod_name)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning('terminate_instances: Error occurred when analyzing '
-                       f'SSH Jump pod: {e}')
+                       f'SSH Jump pod: {e}')   
     try:
+        
         kubernetes.core_api(context).delete_namespaced_service(
             pod_name, namespace, _request_timeout=config_lib.DELETION_TIMEOUT)
         kubernetes.core_api(context).delete_namespaced_service(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -657,9 +657,9 @@ def _terminate_node(namespace: str, context: Optional[str],
         kubernetes_utils.clean_zombie_ssh_jump_pod(namespace, context, pod_name)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning('terminate_instances: Error occurred when analyzing '
-                       f'SSH Jump pod: {e}')   
+                       f'SSH Jump pod: {e}')
     try:
-        
+
         kubernetes.core_api(context).delete_namespaced_service(
             pod_name, namespace, _request_timeout=config_lib.DELETION_TIMEOUT)
         kubernetes.core_api(context).delete_namespaced_service(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This makes it so the podset has only one kind of pod which can work with dws

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
