### PR TITLE
merge user-supplied affinity instead of clobbering it

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -57,8 +57,8 @@ def _merge_spread_anti_affinity(pod_spec: Dict[str, Any],
     existing_affinity = pod_spec['spec'].get('affinity') or {}
     anti_affinity = existing_affinity.get('podAntiAffinity') or {}
     preferred_terms = list(
-        anti_affinity.get('preferredDuringSchedulingIgnoredDuringExecution')
-        or [])
+        anti_affinity.get('preferredDuringSchedulingIgnoredDuringExecution') or
+        [])
     preferred_terms.append(spread_term)
     anti_affinity[
         'preferredDuringSchedulingIgnoredDuringExecution'] = preferred_terms

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -33,6 +33,39 @@ TAG_SKYPILOT_CLUSTER_NAME = 'skypilot-cluster-name'
 TAG_POD_INITIALIZED = 'skypilot-initialized'
 
 
+def _merge_spread_anti_affinity(pod_spec: Dict[str, Any],
+                                cluster_name_on_cloud: str) -> None:
+    """Append SkyPilot's worker-spread podAntiAffinity term in place.
+
+    Preserves any user-supplied nodeAffinity / podAffinity /
+    podAntiAffinity set via pod_config instead of overwriting
+    spec.affinity wholesale.
+    """
+    spread_term = {
+        'weight': 100,
+        'podAffinityTerm': {
+            'labelSelector': {
+                'matchExpressions': [{
+                    'key': TAG_SKYPILOT_CLUSTER_NAME,
+                    'operator': 'In',
+                    'values': [cluster_name_on_cloud]
+                }]
+            },
+            'topologyKey': 'kubernetes.io/hostname'
+        }
+    }
+    existing_affinity = pod_spec['spec'].get('affinity') or {}
+    anti_affinity = existing_affinity.get('podAntiAffinity') or {}
+    preferred_terms = list(
+        anti_affinity.get('preferredDuringSchedulingIgnoredDuringExecution')
+        or [])
+    preferred_terms.append(spread_term)
+    anti_affinity[
+        'preferredDuringSchedulingIgnoredDuringExecution'] = preferred_terms
+    existing_affinity['podAntiAffinity'] = anti_affinity
+    pod_spec['spec']['affinity'] = existing_affinity
+
+
 def _get_head_pod_name(pods: Dict[str, Any]) -> Optional[str]:
     head_pod_name = None
     for pod_name, pod in pods.items():
@@ -758,26 +791,9 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
         # are not available, we still want to be able to schedule worker
         # pods on larger nodes which may be able to fit multiple SkyPilot
         # "nodes".
-        pod_spec_copy['spec']['affinity'] = {
-            'podAntiAffinity': {
-                # Set as a soft constraint
-                'preferredDuringSchedulingIgnoredDuringExecution': [{
-                    # Max weight to avoid scheduling on the
-                    # same physical node unless necessary.
-                    'weight': 100,
-                    'podAffinityTerm': {
-                        'labelSelector': {
-                            'matchExpressions': [{
-                                'key': TAG_SKYPILOT_CLUSTER_NAME,
-                                'operator': 'In',
-                                'values': [cluster_name_on_cloud]
-                            }]
-                        },
-                        'topologyKey': 'kubernetes.io/hostname'
-                    }
-                }]
-            }
-        }
+        # Merge into any user-supplied affinity (e.g. nodeAffinity from
+        # pod_config) rather than overwriting it.
+        _merge_spread_anti_affinity(pod_spec_copy, cluster_name_on_cloud)
 
         # TPU slice nodes are given a taint, google.com/tpu=present:NoSchedule.
         # This is to prevent from non-TPU workloads from being scheduled on TPU

--- a/tests/unit_tests/test_kubernetes_instance.py
+++ b/tests/unit_tests/test_kubernetes_instance.py
@@ -2,7 +2,6 @@
 
 from sky.provision.kubernetes import instance
 
-
 CLUSTER = 'my-cluster'
 
 
@@ -59,7 +58,9 @@ def test_merge_spread_anti_affinity_appends_to_existing_anti_affinity():
         'weight': 50,
         'podAffinityTerm': {
             'labelSelector': {
-                'matchLabels': {'app': 'other'},
+                'matchLabels': {
+                    'app': 'other'
+                },
             },
             'topologyKey': 'topology.kubernetes.io/zone',
         },

--- a/tests/unit_tests/test_kubernetes_instance.py
+++ b/tests/unit_tests/test_kubernetes_instance.py
@@ -1,0 +1,83 @@
+"""Tests for sky.provision.kubernetes.instance helpers."""
+
+from sky.provision.kubernetes import instance
+
+
+CLUSTER = 'my-cluster'
+
+
+def _spread_term():
+    return {
+        'weight': 100,
+        'podAffinityTerm': {
+            'labelSelector': {
+                'matchExpressions': [{
+                    'key': instance.TAG_SKYPILOT_CLUSTER_NAME,
+                    'operator': 'In',
+                    'values': [CLUSTER],
+                }],
+            },
+            'topologyKey': 'kubernetes.io/hostname',
+        },
+    }
+
+
+def test_merge_spread_anti_affinity_empty_spec():
+    pod_spec = {'spec': {}}
+    instance._merge_spread_anti_affinity(pod_spec, CLUSTER)
+    assert pod_spec['spec']['affinity'] == {
+        'podAntiAffinity': {
+            'preferredDuringSchedulingIgnoredDuringExecution': [_spread_term()],
+        },
+    }
+
+
+def test_merge_spread_anti_affinity_preserves_user_node_affinity():
+    user_node_affinity = {
+        'requiredDuringSchedulingIgnoredDuringExecution': {
+            'nodeSelectorTerms': [{
+                'matchExpressions': [{
+                    'key': 'kubernetes.io/hostname',
+                    'operator': 'In',
+                    'values': ['10.140.80.58', '10.140.81.74'],
+                }],
+            }],
+        },
+    }
+    pod_spec = {'spec': {'affinity': {'nodeAffinity': user_node_affinity}}}
+
+    instance._merge_spread_anti_affinity(pod_spec, CLUSTER)
+
+    affinity = pod_spec['spec']['affinity']
+    assert affinity['nodeAffinity'] == user_node_affinity
+    assert affinity['podAntiAffinity'][
+        'preferredDuringSchedulingIgnoredDuringExecution'] == [_spread_term()]
+
+
+def test_merge_spread_anti_affinity_appends_to_existing_anti_affinity():
+    user_term = {
+        'weight': 50,
+        'podAffinityTerm': {
+            'labelSelector': {
+                'matchLabels': {'app': 'other'},
+            },
+            'topologyKey': 'topology.kubernetes.io/zone',
+        },
+    }
+    pod_spec = {
+        'spec': {
+            'affinity': {
+                'podAntiAffinity': {
+                    'preferredDuringSchedulingIgnoredDuringExecution': [
+                        user_term
+                    ],
+                },
+            },
+        },
+    }
+
+    instance._merge_spread_anti_affinity(pod_spec, CLUSTER)
+
+    preferred = pod_spec['spec']['affinity']['podAntiAffinity'][
+        'preferredDuringSchedulingIgnoredDuringExecution']
+    assert preferred == [user_term, _spread_term()]


### PR DESCRIPTION
_create_pod_thread unconditionally overwrote spec.affinity with the SkyPilot worker-spread podAntiAffinity, discarding any nodeAffinity / podAffinity the user set via pod_config. Extract the merge into a module-level _merge_spread_anti_affinity helper that preserves existing affinity fields and appends the spread term to any existing podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution, and add unit tests covering empty spec, preserved user nodeAffinity, and appending to existing anti-affinity terms.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
