### PR TITLE
hotfix: bump nightly version by one day to ship affinity fix

### DIFF
--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -40,7 +40,11 @@ jobs:
           --user
       - name: Set release version
         run: |
-          RELEASE_VERSION=$(date +%Y%m%d)
+          # Hotfix: today's nightly already published before the affinity
+          # merge fix landed on master. Bump one day so the new wheel can
+          # actually upload (PyPI permanently reserves filenames). Tomorrow's
+          # cron will hit skip-existing for this version and no-op.
+          RELEASE_VERSION=$(date -u -d "+1 day" +%Y%m%d)
           sed -i "s/{{SKYPILOT_COMMIT_SHA}}/${{ github.sha }}/g" sky/__init__.py
           sed -i "s/__version__ = '.*'/__version__ = '1.0.0.dev${RELEASE_VERSION}'/g" sky/__init__.py
           sed -i "s/name='skypilot',/name='trainy-skypilot-nightly',/g" sky/setup_files/setup.py


### PR DESCRIPTION
## Summary
- Today's 10:35 UTC nightly cron published `trainy-skypilot-nightly==1.0.0.dev20260417` from master before #12 (the user-supplied affinity merge fix) landed.
- PyPI permanently reserves filenames, so re-running `pypi-publish-nightly` against the same date just hits `skip-existing`.
- Bump `RELEASE_VERSION` by one day so this build can actually upload as `1.0.0.dev20260418`. Tomorrow's scheduled cron will hit `skip-existing` for that version and no-op — no harm done.

## Test plan
- [ ] Merge this PR, then `gh workflow run pypi-publish-nightly -R asaiacai/zep --ref master`
- [ ] Confirm `1.0.0.dev20260418` appears at https://pypi.org/project/trainy-skypilot-nightly/
- [ ] Revert this commit so the workflow returns to `date +%Y%m%d` for normal nightly cadence